### PR TITLE
Improve SSO form asset loading reliability

### DIFF
--- a/public/css/pages/myfiles.css
+++ b/public/css/pages/myfiles.css
@@ -52,7 +52,114 @@
     gap: 12px;
 }
 
-.view-toggle {
+.file-filters {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    margin-bottom: 20px;
+}
+
+.search-wrapper {
+    flex: 1 1 240px;
+    max-width: 420px;
+    position: relative;
+}
+
+.search-wrapper i {
+    position: absolute;
+    top: 50%;
+    left: 14px;
+    transform: translateY(-50%);
+    color: #a0aec0;
+    font-size: 14px;
+}
+
+#file-search {
+    width: 100%;
+    padding: 10px 14px 10px 38px;
+    border: 1px solid #e2e8f0;
+    border-radius: 10px;
+    font-size: 14px;
+    transition: all 0.2s ease;
+    background-color: #f9fafb;
+}
+
+#file-search:focus {
+    outline: none;
+    border-color: #667eea;
+    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.2);
+    background-color: white;
+}
+
+.sort-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.sort-wrapper label {
+    font-size: 14px;
+    font-weight: 600;
+    color: #4a5568;
+}
+
+#file-sort {
+    border: 1px solid #e2e8f0;
+    border-radius: 10px;
+    padding: 9px 38px 9px 14px;
+    font-size: 14px;
+    background: white url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="12" height="8" viewBox="0 0 12 8"%3E%3Cpath fill="%23667896" d="M1.41 0L6 4.58 10.59 0 12 1.41 6 7.41 0 1.41z"/%3E%3C/svg%3E') no-repeat right 12px center;
+    appearance: none;
+    cursor: pointer;
+    transition: border-color 0.2s ease;
+}
+
+#file-sort:focus {
+    outline: none;
+    border-color: #667eea;
+    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.2);
+}
+
+.view-toggle-group {
+    display: inline-flex;
+    align-items: center;
+    border: 1px solid #e2e8f0;
+    border-radius: 10px;
+    overflow: hidden;
+    background: white;
+}
+
+.view-toggle-btn {
+    border: none;
+    background: transparent;
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    color: #718096;
+    transition: all 0.2s ease;
+}
+
+.view-toggle-btn + .view-toggle-btn {
+    border-left: 1px solid #e2e8f0;
+}
+
+.view-toggle-btn:hover {
+    background: #f7fafc;
+    color: #4a5568;
+}
+
+.view-toggle-btn.is-active {
+    background: #eef2ff;
+    color: #4c51bf;
+    box-shadow: inset 0 0 0 1px rgba(102, 126, 234, 0.35);
+}
+
+.icon-button {
     background: white;
     border: 1px solid #e2e8f0;
     border-radius: 8px;
@@ -66,7 +173,7 @@
     transition: all 0.2s ease;
 }
 
-.view-toggle:hover {
+.icon-button:hover {
     background: #f7fafc;
     border-color: #cbd5e0;
     color: #4a5568;
@@ -106,6 +213,31 @@
 
 .files-content.has-files {
     display: block;
+}
+
+.no-results {
+    padding: 48px 20px;
+    text-align: center;
+    color: #4a5568;
+}
+
+.no-results i {
+    font-size: 32px;
+    color: #667eea;
+    margin-bottom: 12px;
+}
+
+.no-results h3 {
+    font-size: 20px;
+    font-weight: 600;
+    margin-bottom: 8px;
+}
+
+.no-results p {
+    font-size: 14px;
+    color: #718096;
+    max-width: 360px;
+    margin: 0 auto;
 }
 
 /* Compact Empty State */
@@ -243,6 +375,20 @@
     .header-actions {
         width: 100%;
         justify-content: space-between;
+    }
+
+    .file-filters {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .sort-wrapper {
+        width: 100%;
+        justify-content: space-between;
+    }
+
+    #file-sort {
+        width: 100%;
     }
     
     .empty-state {
@@ -467,6 +613,7 @@
 .file-list.grid-view .file-actions {
     justify-content: center;
     margin-top: 8px;
+    opacity: 1;
 }
 
 .action-btn {
@@ -489,6 +636,22 @@
     color: white;
     border-color: #667eea;
     transform: scale(1.1);
+}
+
+.action-btn.share-toggle-btn {
+    transition: all 0.2s ease;
+}
+
+.action-btn.share-toggle-btn.is-public {
+    background: #e6fffa;
+    border-color: #38b2ac;
+    color: #2c7a7b;
+}
+
+.action-btn.share-toggle-btn.is-public:hover {
+    background: #38b2ac;
+    color: white;
+    border-color: #38b2ac;
 }
 
 /* Drag over state for container */

--- a/public/css/pages/sso/auth.css
+++ b/public/css/pages/sso/auth.css
@@ -1,0 +1,209 @@
+:root {
+    --auth-bg: #f8f9fa;
+    --auth-card-bg: #ffffff;
+    --auth-border: #e5e7eb;
+    --auth-primary: #6366f1;
+    --auth-primary-dark: #4f46e5;
+    --auth-text: #1f2937;
+    --auth-muted: #6b7280;
+    --auth-radius: 14px;
+    --auth-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+}
+
+body {
+    background: var(--auth-bg);
+    color: var(--auth-text);
+}
+
+.auth-wrapper {
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 32px 16px;
+}
+
+.auth-card {
+    width: 100%;
+    max-width: 420px;
+    background: var(--auth-card-bg);
+    border-radius: var(--auth-radius);
+    box-shadow: var(--auth-shadow);
+    border: 1px solid var(--auth-border);
+    padding: 32px;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.auth-logo {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-weight: 600;
+    font-size: 18px;
+    color: var(--auth-primary);
+}
+
+.auth-logo span {
+    color: var(--auth-text);
+}
+
+.auth-header {
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.auth-header h1 {
+    font-size: 24px;
+    font-weight: 600;
+}
+
+.auth-header p {
+    font-size: 15px;
+    color: var(--auth-muted);
+}
+
+.auth-form {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.auth-alert {
+    display: none;
+    padding: 12px 14px;
+    border-radius: 10px;
+    font-size: 14px;
+    line-height: 1.5;
+}
+
+.auth-alert.is-error {
+    display: block;
+    background: #fef2f2;
+    color: #b91c1c;
+    border: 1px solid #fecaca;
+}
+
+.auth-alert.is-success {
+    display: block;
+    background: #ecfdf5;
+    color: #047857;
+    border: 1px solid #a7f3d0;
+}
+
+.form-field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.form-field label {
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--auth-text);
+}
+
+.form-field input {
+    width: 100%;
+    padding: 12px 14px;
+    border-radius: 10px;
+    border: 1px solid var(--auth-border);
+    font-size: 15px;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.form-field input:focus {
+    outline: none;
+    border-color: var(--auth-primary);
+    box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
+}
+
+.password-field {
+    position: relative;
+}
+
+.password-toggle {
+    position: absolute;
+    top: 50%;
+    right: 12px;
+    transform: translateY(-50%);
+    background: none;
+    border: none;
+    color: var(--auth-primary);
+    font-weight: 600;
+    cursor: pointer;
+    padding: 0;
+}
+
+.auth-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.btn-primary {
+    width: 100%;
+    padding: 12px 16px;
+    border: none;
+    border-radius: 10px;
+    background: var(--auth-primary);
+    color: #ffffff;
+    font-weight: 600;
+    font-size: 15px;
+    cursor: pointer;
+    transition: background 0.2s ease;
+}
+
+.btn-primary:hover {
+    background: var(--auth-primary-dark);
+}
+
+.form-support {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 14px;
+}
+
+.form-support label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    color: var(--auth-muted);
+}
+
+.form-support a,
+.auth-footer a,
+.auth-switch a {
+    color: var(--auth-primary);
+    font-weight: 500;
+    text-decoration: none;
+}
+
+.form-support a:hover,
+.auth-footer a:hover,
+.auth-switch a:hover {
+    text-decoration: underline;
+}
+
+.auth-footer,
+.auth-switch {
+    text-align: center;
+    font-size: 14px;
+    color: var(--auth-muted);
+}
+
+@media (max-width: 480px) {
+    .auth-card {
+        padding: 24px;
+    }
+
+    .form-support {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 8px;
+    }
+}

--- a/public/html/pages/myfiles.html
+++ b/public/html/pages/myfiles.html
@@ -12,10 +12,15 @@
                 </div>
             </div>
             <div class="header-actions">
-                <button class="view-toggle" data-view="list" title="Chuyển chế độ xem">
-                    <i class="fas fa-list"></i>
-                </button>
-                <button class="view-toggle" onclick="refreshFiles()" title="Làm mới danh sách">
+                <div class="view-toggle-group" role="group" aria-label="Chế độ hiển thị">
+                    <button class="view-toggle-btn is-active" data-view="list" title="Hiển thị dạng danh sách">
+                        <i class="fas fa-list"></i>
+                    </button>
+                    <button class="view-toggle-btn" data-view="grid" title="Hiển thị dạng lưới">
+                        <i class="fas fa-th-large"></i>
+                    </button>
+                </div>
+                <button class="icon-button" onclick="refreshFiles()" title="Làm mới danh sách">
                     <i class="fas fa-sync-alt"></i>
                 </button>
                 <button class="btn-upload" onclick="window.loadPage('upload')">
@@ -25,6 +30,24 @@
             </div>
         </div>
         
+        <div class="file-filters">
+            <div class="search-wrapper">
+                <i class="fas fa-search"></i>
+                <input type="text" id="file-search" placeholder="Tìm kiếm tệp theo tên, loại..." aria-label="Tìm kiếm tệp">
+            </div>
+            <div class="sort-wrapper">
+                <label for="file-sort">Sắp xếp:</label>
+                <select id="file-sort" aria-label="Sắp xếp tệp">
+                    <option value="date-desc">Ngày tải lên (mới nhất)</option>
+                    <option value="date-asc">Ngày tải lên (cũ nhất)</option>
+                    <option value="name-asc">Tên (A-Z)</option>
+                    <option value="name-desc">Tên (Z-A)</option>
+                    <option value="size-desc">Dung lượng (lớn nhất)</option>
+                    <option value="size-asc">Dung lượng (nhỏ nhất)</option>
+                </select>
+            </div>
+        </div>
+
         <div class="files-content" id="files-content">
             <!-- Files will be loaded here -->
         </div>

--- a/public/html/pages/sso/forgot-password.html
+++ b/public/html/pages/sso/forgot-password.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>BeamShare - Quên mật khẩu</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" integrity="sha512-8oCOHYKT8pi7M/Wq3iCt3vEGI7XWuf5NTau62JXpkkn00L6UNkTpZ1PS8CNo2i7Tt2n7O6U6D3lWq2RfDX0X7Q==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="../../../css/base.css" onerror="this.onerror=null;this.href='/public/css/base.css';">
+    <link rel="stylesheet" href="../../../css/pages/sso/auth.css" onerror="this.onerror=null;this.href='/public/css/pages/sso/auth.css';">
+</head>
+<body>
+    <div class="auth-wrapper">
+        <div class="auth-card" data-page="forgot">
+            <div class="auth-logo">
+                <i class="fas fa-cloud"></i>
+            </div>
+            <div class="auth-header">
+                <h1>Quên mật khẩu</h1>
+                <p>Nhập email để nhận hướng dẫn đặt lại mật khẩu.</p>
+            </div>
+            <form class="auth-form" id="forgot-form" data-form-type="forgot">
+                <div class="auth-alert" role="alert"></div>
+                <div class="form-field">
+                    <label for="forgot-email">Email đăng ký</label>
+                    <input type="email" id="forgot-email" name="email" placeholder="name@email.com" required>
+                </div>
+                <div class="auth-actions">
+                    <button type="submit" class="btn-primary">Gửi hướng dẫn</button>
+                </div>
+            </form>
+            <div class="auth-footer">
+                <a href="login.html">Quay lại đăng nhập</a>
+            </div>
+        </div>
+    </div>
+    <script>
+        (function loadAuthAssets() {
+            const ensureStyles = (selector, expectedBackground) => {
+                window.addEventListener('load', () => {
+                    const card = document.querySelector(selector);
+                    if (!card) return;
+                    const styles = window.getComputedStyle(card);
+                    if (!styles || styles.backgroundColor === expectedBackground) {
+                        ['/public/css/base.css', '/public/css/pages/sso/auth.css'].forEach((href) => {
+                            if ([...document.styleSheets].some(sheet => sheet.href && sheet.href.endsWith(href))) {
+                                return;
+                            }
+                            const fallbackLink = document.createElement('link');
+                            fallbackLink.rel = 'stylesheet';
+                            fallbackLink.href = href;
+                            document.head.appendChild(fallbackLink);
+                        });
+                    }
+                });
+            };
+
+            ensureStyles('.auth-card', 'rgba(0, 0, 0, 0)');
+
+            const primarySrc = '../../../js/pages/sso/auth.js';
+            const fallbackSrc = '/public/js/pages/sso/auth.js';
+            const script = document.createElement('script');
+            script.src = primarySrc;
+            script.defer = true;
+            script.onerror = () => {
+                const fallbackScript = document.createElement('script');
+                fallbackScript.defer = true;
+                fallbackScript.src = fallbackSrc;
+                document.body.appendChild(fallbackScript);
+            };
+            document.body.appendChild(script);
+        })();
+    </script>
+</body>
+</html>

--- a/public/html/pages/sso/login.html
+++ b/public/html/pages/sso/login.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>BeamShare - Đăng nhập</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" integrity="sha512-8oCOHYKT8pi7M/Wq3iCt3vEGI7XWuf5NTau62JXpkkn00L6UNkTpZ1PS8CNo2i7Tt2n7O6U6D3lWq2RfDX0X7Q==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="../../../css/base.css" onerror="this.onerror=null;this.href='/public/css/base.css';">
+    <link rel="stylesheet" href="../../../css/pages/sso/auth.css" onerror="this.onerror=null;this.href='/public/css/pages/sso/auth.css';">
+</head>
+<body>
+    <div class="auth-wrapper">
+        <div class="auth-card" data-page="login">
+            <div class="auth-logo">
+                <i class="fas fa-cloud"></i>
+            </div>
+            <div class="auth-header">
+                <h1>Chào mừng trở lại</h1>
+                <p>Đăng nhập để quản lý và chia sẻ tệp tin của bạn.</p>
+            </div>
+            <form class="auth-form" id="login-form" data-form-type="login">
+                <div class="auth-alert" role="alert"></div>
+                <div class="form-field">
+                    <label for="login-email">Email</label>
+                    <input type="email" id="login-email" name="email" placeholder="name@email.com" autocomplete="username" required>
+                </div>
+                <div class="form-field password-field">
+                    <label for="login-password">Mật khẩu</label>
+                    <input type="password" id="login-password" name="password" placeholder="••••••••" autocomplete="current-password" required minlength="6">
+                    <button type="button" class="password-toggle" aria-label="Hiển thị mật khẩu">Hiện</button>
+                </div>
+                <div class="form-support">
+                    <label>
+                        <input type="checkbox" name="remember" checked>
+                        Ghi nhớ tôi
+                    </label>
+                    <a href="forgot-password.html">Quên mật khẩu?</a>
+                </div>
+                <div class="auth-actions">
+                    <button type="submit" class="btn-primary">Đăng nhập</button>
+                </div>
+            </form>
+            <div class="auth-footer">
+                Chưa có tài khoản? <a href="register.html">Đăng ký ngay</a>
+            </div>
+        </div>
+    </div>
+    <script>
+        (function loadAuthAssets() {
+            const ensureStyles = (selector, expectedBackground) => {
+                window.addEventListener('load', () => {
+                    const card = document.querySelector(selector);
+                    if (!card) return;
+                    const styles = window.getComputedStyle(card);
+                    if (!styles || styles.backgroundColor === expectedBackground) {
+                        ['/public/css/base.css', '/public/css/pages/sso/auth.css'].forEach((href) => {
+                            if ([...document.styleSheets].some(sheet => sheet.href && sheet.href.endsWith(href))) {
+                                return;
+                            }
+                            const fallbackLink = document.createElement('link');
+                            fallbackLink.rel = 'stylesheet';
+                            fallbackLink.href = href;
+                            document.head.appendChild(fallbackLink);
+                        });
+                    }
+                });
+            };
+
+            ensureStyles('.auth-card', 'rgba(0, 0, 0, 0)');
+
+            const primarySrc = '../../../js/pages/sso/auth.js';
+            const fallbackSrc = '/public/js/pages/sso/auth.js';
+            const script = document.createElement('script');
+            script.src = primarySrc;
+            script.defer = true;
+            script.onerror = () => {
+                const fallbackScript = document.createElement('script');
+                fallbackScript.defer = true;
+                fallbackScript.src = fallbackSrc;
+                document.body.appendChild(fallbackScript);
+            };
+            document.body.appendChild(script);
+        })();
+    </script>
+</body>
+</html>

--- a/public/html/pages/sso/register.html
+++ b/public/html/pages/sso/register.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>BeamShare - Đăng ký</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" integrity="sha512-8oCOHYKT8pi7M/Wq3iCt3vEGI7XWuf5NTau62JXpkkn00L6UNkTpZ1PS8CNo2i7Tt2n7O6U6D3lWq2RfDX0X7Q==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="../../../css/base.css" onerror="this.onerror=null;this.href='/public/css/base.css';">
+    <link rel="stylesheet" href="../../../css/pages/sso/auth.css" onerror="this.onerror=null;this.href='/public/css/pages/sso/auth.css';">
+</head>
+<body>
+    <div class="auth-wrapper">
+        <div class="auth-card" data-page="register">
+            <div class="auth-logo">
+                <i class="fas fa-cloud"></i>
+            </div>
+            <div class="auth-header">
+                <h1>Tạo tài khoản mới</h1>
+                <p>Đăng ký nhanh để bắt đầu lưu trữ và chia sẻ.</p>
+            </div>
+            <form class="auth-form" id="register-form" data-form-type="register">
+                <div class="auth-alert" role="alert"></div>
+                <div class="form-field">
+                    <label for="register-name">Họ và tên</label>
+                    <input type="text" id="register-name" name="name" placeholder="Nguyễn Văn A" autocomplete="name" required>
+                </div>
+                <div class="form-field">
+                    <label for="register-email">Email</label>
+                    <input type="email" id="register-email" name="email" placeholder="name@email.com" autocomplete="email" required>
+                </div>
+                <div class="form-field password-field">
+                    <label for="register-password">Mật khẩu</label>
+                    <input type="password" id="register-password" name="password" placeholder="Tối thiểu 6 ký tự" minlength="6" required>
+                    <button type="button" class="password-toggle" aria-label="Hiển thị mật khẩu">Hiện</button>
+                </div>
+                <div class="form-field password-field">
+                    <label for="register-confirm">Nhập lại mật khẩu</label>
+                    <input type="password" id="register-confirm" name="confirm" placeholder="Nhập lại mật khẩu" minlength="6" required>
+                    <button type="button" class="password-toggle" aria-label="Hiển thị mật khẩu">Hiện</button>
+                </div>
+                <div class="form-support">
+                    <label>
+                        <input type="checkbox" name="terms" required>
+                        Tôi đồng ý với điều khoản sử dụng
+                    </label>
+                </div>
+                <div class="auth-actions">
+                    <button type="submit" class="btn-primary">Đăng ký</button>
+                </div>
+            </form>
+            <div class="auth-switch">
+                Đã có tài khoản? <a href="login.html">Đăng nhập</a>
+            </div>
+        </div>
+    </div>
+    <script>
+        (function loadAuthAssets() {
+            const ensureStyles = (selector, expectedBackground) => {
+                window.addEventListener('load', () => {
+                    const card = document.querySelector(selector);
+                    if (!card) return;
+                    const styles = window.getComputedStyle(card);
+                    if (!styles || styles.backgroundColor === expectedBackground) {
+                        ['/public/css/base.css', '/public/css/pages/sso/auth.css'].forEach((href) => {
+                            if ([...document.styleSheets].some(sheet => sheet.href && sheet.href.endsWith(href))) {
+                                return;
+                            }
+                            const fallbackLink = document.createElement('link');
+                            fallbackLink.rel = 'stylesheet';
+                            fallbackLink.href = href;
+                            document.head.appendChild(fallbackLink);
+                        });
+                    }
+                });
+            };
+
+            ensureStyles('.auth-card', 'rgba(0, 0, 0, 0)');
+
+            const primarySrc = '../../../js/pages/sso/auth.js';
+            const fallbackSrc = '/public/js/pages/sso/auth.js';
+            const script = document.createElement('script');
+            script.src = primarySrc;
+            script.defer = true;
+            script.onerror = () => {
+                const fallbackScript = document.createElement('script');
+                fallbackScript.defer = true;
+                fallbackScript.src = fallbackSrc;
+                document.body.appendChild(fallbackScript);
+            };
+            document.body.appendChild(script);
+        })();
+    </script>
+</body>
+</html>

--- a/public/js/pages/myfiles.js
+++ b/public/js/pages/myfiles.js
@@ -1,43 +1,19 @@
 // My Files Page JavaScript - Compact
+const DEFAULT_SORT_OPTION = 'date-desc';
+const DEFAULT_VIEW_MODE = 'list';
+const VIEW_MODE_STORAGE_KEY = 'myfiles:view-mode';
+let allFiles = [];
+let filteredFiles = [];
+let activeSortOption = DEFAULT_SORT_OPTION;
+let searchDebounceTimer = null;
+let activeViewMode = DEFAULT_VIEW_MODE;
+
 window.initMyFiles = function() {
     console.log('Initializing My Files page...');
-    
-    // Simple view toggle functionality
-    const viewToggle = document.querySelector('.view-toggle');
-    const filesContent = document.getElementById('files-content');
-    let currentView = 'list';
-    
-    if (viewToggle) {
-        viewToggle.addEventListener('click', function() {
-            currentView = currentView === 'list' ? 'grid' : 'list';
-            
-            // Update icon
-            const icon = this.querySelector('i');
-            icon.className = currentView === 'list' ? 'fas fa-list' : 'fas fa-th';
-            
-            // Apply view transformation (if files exist)
-            if (filesContent) {
-                if (currentView === 'grid') {
-                    filesContent.classList.add('grid-view');
-                    filesContent.classList.remove('list-view');
-                } else {
-                    filesContent.classList.add('list-view');
-                    filesContent.classList.remove('grid-view');
-                }
-            }
-            
-            // Show notification for view change
-            if (window.toastSystem) {
-                window.toastSystem.info(`Chế độ xem: ${currentView === 'grid' ? 'Lưới' : 'Danh sách'}`, {
-                    duration: 2000
-                });
-            }
-        });
-    }
-    
+
     // Initialize drag and drop for the entire page
     initDragAndDrop();
-    
+
     // Initialize UI
     initializeUI();
     
@@ -130,8 +106,130 @@ function initDragAndDrop() {
 
 // Simple initialization
 function initializeUI() {
-    // Simple UI setup if needed
+    setupSearchAndSort();
+    setupViewToggles();
     console.log('UI initialized');
+}
+
+function setupSearchAndSort() {
+    const searchInput = document.getElementById('file-search');
+    const sortSelect = document.getElementById('file-sort');
+
+    if (sortSelect) {
+        sortSelect.value = activeSortOption;
+        sortSelect.addEventListener('change', event => {
+            activeSortOption = event.target.value || DEFAULT_SORT_OPTION;
+            applyFiltersAndRender();
+        });
+    }
+
+    if (searchInput) {
+        searchInput.addEventListener('input', () => {
+            if (searchDebounceTimer) {
+                clearTimeout(searchDebounceTimer);
+            }
+            searchDebounceTimer = setTimeout(() => {
+                applyFiltersAndRender();
+            }, 200);
+        });
+    }
+}
+
+function setupViewToggles() {
+    const toggleButtons = Array.from(document.querySelectorAll('.view-toggle-btn'));
+
+    if (!toggleButtons.length) {
+        return;
+    }
+
+    setActiveViewMode(getStoredViewMode(), { skipStorage: true });
+
+    toggleButtons.forEach(button => {
+        const requestedMode = button.getAttribute('data-view');
+        const normalizedMode = requestedMode === 'grid' ? 'grid' : 'list';
+
+        button.setAttribute('aria-pressed', normalizedMode === activeViewMode ? 'true' : 'false');
+
+        button.addEventListener('click', () => {
+            const mode = button.getAttribute('data-view') === 'grid' ? 'grid' : 'list';
+            const hasChanged = setActiveViewMode(mode);
+
+            if (!hasChanged) {
+                return;
+            }
+
+            renderFileList(filteredFiles);
+
+            if (window.toastSystem) {
+                window.toastSystem.info(`Đang hiển thị dạng ${mode === 'grid' ? 'lưới' : 'danh sách'}`, {
+                    duration: 2000
+                });
+            }
+        });
+    });
+
+    syncViewToggleUI();
+    updateFilesContentView();
+}
+
+function setActiveViewMode(mode, options = {}) {
+    const normalized = mode === 'grid' ? 'grid' : 'list';
+    const hasChanged = normalized !== activeViewMode;
+    activeViewMode = normalized;
+
+    if (!options.skipStorage) {
+        saveViewMode(activeViewMode);
+    }
+
+    syncViewToggleUI();
+    updateFilesContentView();
+
+    return hasChanged;
+}
+
+function syncViewToggleUI() {
+    const toggleButtons = document.querySelectorAll('.view-toggle-btn');
+
+    toggleButtons.forEach(button => {
+        const buttonMode = button.getAttribute('data-view') === 'grid' ? 'grid' : 'list';
+        const isActive = buttonMode === activeViewMode;
+
+        button.classList.toggle('is-active', isActive);
+        button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    });
+}
+
+function updateFilesContentView(element) {
+    const filesContent = element || document.getElementById('files-content');
+
+    if (!filesContent) {
+        return;
+    }
+
+    filesContent.setAttribute('data-view-mode', activeViewMode);
+    filesContent.classList.toggle('grid-view', activeViewMode === 'grid');
+    filesContent.classList.toggle('list-view', activeViewMode !== 'grid');
+}
+
+function getStoredViewMode() {
+    try {
+        const stored = window.localStorage.getItem(VIEW_MODE_STORAGE_KEY);
+        if (stored === 'grid' || stored === 'list') {
+            return stored;
+        }
+    } catch (error) {
+        console.warn('Không thể truy cập localStorage để đọc chế độ xem:', error);
+    }
+
+    return DEFAULT_VIEW_MODE;
+}
+
+function saveViewMode(mode) {
+    try {
+        window.localStorage.setItem(VIEW_MODE_STORAGE_KEY, mode);
+    } catch (error) {
+        console.warn('Không thể lưu chế độ xem vào localStorage:', error);
+    }
 }
 
 // Load files from server
@@ -139,37 +237,12 @@ async function loadFiles() {
     try {
         const response = await fetch('/api/files');
         const files = await response.json();
-        
-        const filesContent = document.getElementById('files-content');
-        const emptyState = document.getElementById('empty-state');
-        
-        if (files && files.length > 0) {
-            // Hide empty state and show files
-            if (emptyState) emptyState.style.display = 'none';
-            if (filesContent) {
-                filesContent.classList.add('has-files');
-                filesContent.style.display = 'block';
-                filesContent.innerHTML = createFileListHTML(files);
-                
-                // Update file count
-                updateFileCount(files);
-                
-                // Add file interactions
-                addFileInteractions();
-            }
-            
-            console.log(`Loaded ${files.length} files successfully`);
+        const fetchedFiles = Array.isArray(files) ? files : [];
+        setAllFiles(fetchedFiles);
+
+        if (fetchedFiles.length > 0) {
+            console.log(`Loaded ${fetchedFiles.length} files successfully`);
         } else {
-            // Show empty state
-            if (emptyState) emptyState.style.display = 'block';
-            if (filesContent) {
-                filesContent.classList.remove('has-files');
-                filesContent.style.display = 'none';
-            }
-            
-            // Update file count
-            updateFileCount([]);
-            
             console.log('No files found');
         }
     } catch (error) {
@@ -182,15 +255,231 @@ async function loadFiles() {
     }
 }
 
+function setAllFiles(files) {
+    allFiles = Array.isArray(files) ? [...files] : [];
+    applyFiltersAndRender();
+}
+
+function applyFiltersAndRender() {
+    const searchInput = document.getElementById('file-search');
+    const sortSelect = document.getElementById('file-sort');
+
+    const searchTerm = searchInput ? searchInput.value.trim().toLowerCase() : '';
+    const sortOption = sortSelect ? sortSelect.value || DEFAULT_SORT_OPTION : DEFAULT_SORT_OPTION;
+
+    activeSortOption = sortOption;
+
+    let workingFiles = [...allFiles];
+
+    if (searchTerm) {
+        workingFiles = workingFiles.filter(file => {
+            const name = (file.displayName || file.originalName || file.name || '').toLowerCase();
+            const type = (file.type || '').toLowerCase();
+            const extension = (file.extension || '').toLowerCase();
+            const tags = Array.isArray(file.tags) ? file.tags.join(' ').toLowerCase() : '';
+
+            return (
+                name.includes(searchTerm) ||
+                type.includes(searchTerm) ||
+                extension.includes(searchTerm) ||
+                tags.includes(searchTerm)
+            );
+        });
+    }
+
+    filteredFiles = sortFiles(workingFiles, sortOption);
+    renderFileList(filteredFiles);
+}
+
+function renderFileList(files) {
+    const filesContent = document.getElementById('files-content');
+    const emptyState = document.getElementById('empty-state');
+
+    updateFilesContentView(filesContent);
+
+    if (!filesContent) {
+        return;
+    }
+
+    const workingFiles = Array.isArray(files) ? files : filteredFiles;
+
+    if (!allFiles.length) {
+        if (emptyState) emptyState.style.display = 'block';
+        filesContent.classList.remove('has-files');
+        filesContent.style.display = 'none';
+        filesContent.innerHTML = '';
+        updateFileCount([], 0);
+        return;
+    }
+
+    if (emptyState) emptyState.style.display = 'none';
+    filesContent.classList.add('has-files');
+    filesContent.style.display = 'block';
+
+    if (!workingFiles.length) {
+        filesContent.innerHTML = `
+            <div class="no-results">
+                <i class="fas fa-search"></i>
+                <h3>Không tìm thấy tệp phù hợp</h3>
+                <p>Thử điều chỉnh từ khóa tìm kiếm hoặc thay đổi tiêu chí sắp xếp.</p>
+            </div>
+        `;
+        updateFileCount(workingFiles, allFiles.length);
+        return;
+    }
+
+    filesContent.innerHTML = createFileListHTML(workingFiles);
+    updateFileCount(workingFiles, allFiles.length);
+    addFileInteractions();
+}
+
+function sortFiles(files, sortOption) {
+    const sortedFiles = [...files];
+    sortedFiles.sort((a, b) => {
+        switch (sortOption) {
+            case 'name-asc':
+                return getComparableName(a).localeCompare(getComparableName(b), 'vi', { sensitivity: 'base' });
+            case 'name-desc':
+                return getComparableName(b).localeCompare(getComparableName(a), 'vi', { sensitivity: 'base' });
+            case 'date-asc':
+                return getUploadTimestamp(a) - getUploadTimestamp(b);
+            case 'size-asc':
+                return getFileSizeValue(a) - getFileSizeValue(b);
+            case 'size-desc':
+                return getFileSizeValue(b) - getFileSizeValue(a);
+            case 'date-desc':
+            default:
+                return getUploadTimestamp(b) - getUploadTimestamp(a);
+        }
+    });
+
+    return sortedFiles;
+}
+
+function getComparableName(file) {
+    return (file.displayName || file.originalName || file.name || '').toLowerCase();
+}
+
+function getUploadTimestamp(file) {
+    const candidates = [
+        file?.uploadDate,
+        file?.uploadedAt,
+        file?.createdAt,
+        file?.updatedAt,
+        file?.lastModified,
+        file?.metadata?.uploadDate,
+        file?.metadata?.uploadedAt,
+        file?.metadata?.createdAt,
+        file?.metadata?.updatedAt,
+        file?.metadata?.lastModified
+    ];
+
+    for (const candidate of candidates) {
+        const parsed = new Date(candidate);
+        if (!Number.isNaN(parsed.getTime())) {
+            return parsed.getTime();
+        }
+    }
+
+    return 0;
+}
+
+function getFileSizeValue(file) {
+    const size = typeof file.size === 'number' ? file.size : Number(file.size);
+    if (!Number.isNaN(size)) {
+        return size;
+    }
+
+    if (file.metadata && typeof file.metadata.size === 'number') {
+        return file.metadata.size;
+    }
+
+    return 0;
+}
+
+function getDisplayDateValue(file) {
+    const timestamp = getUploadTimestamp(file);
+    if (!timestamp) {
+        return null;
+    }
+
+    const date = new Date(timestamp);
+    if (Number.isNaN(date.getTime())) {
+        return null;
+    }
+
+    return date.toISOString();
+}
+
+function escapeHtml(value) {
+    if (value === null || value === undefined) {
+        return '';
+    }
+
+    return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+function escapeForJsString(value) {
+    if (value === null || value === undefined) {
+        return '';
+    }
+
+    return String(value)
+        .replace(/\\/g, '\\\\')
+        .replace(/'/g, "\\'")
+        .replace(/\n/g, '\\n')
+        .replace(/\r/g, '\\r');
+}
+
 // Create sample files for demonstration
 window.createSampleFiles = function() {
+    const now = Date.now();
     const sampleFiles = [
-        { name: 'Tài liệu dự án.pdf', size: '2.5 MB', type: 'pdf', date: '2 giờ trước' },
-        { name: 'Hình ảnh logo.png', size: '890 KB', type: 'image', date: '1 ngày trước' },
-        { name: 'Bản trình bày.pptx', size: '5.2 MB', type: 'presentation', date: '3 ngày trước' },
-        { name: 'Dữ liệu bán hàng.xlsx', size: '1.8 MB', type: 'spreadsheet', date: '1 tuần trước' }
+        {
+            id: 'sample-doc',
+            originalName: 'Tài liệu dự án.pdf',
+            displayName: 'Tài liệu dự án.pdf',
+            size: 2.5 * 1024 * 1024,
+            type: 'application/pdf',
+            uploadDate: new Date(now - 2 * 60 * 60 * 1000).toISOString(),
+            extension: '.pdf',
+            isDocument: true
+        },
+        {
+            id: 'sample-image',
+            originalName: 'Hình ảnh logo.png',
+            displayName: 'Hình ảnh logo.png',
+            size: 890 * 1024,
+            type: 'image/png',
+            uploadDate: new Date(now - 24 * 60 * 60 * 1000).toISOString(),
+            extension: '.png',
+            isImage: true
+        },
+        {
+            id: 'sample-presentation',
+            originalName: 'Bản trình bày.pptx',
+            displayName: 'Bản trình bày.pptx',
+            size: 5.2 * 1024 * 1024,
+            type: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+            uploadDate: new Date(now - 3 * 24 * 60 * 60 * 1000).toISOString(),
+            extension: '.pptx'
+        },
+        {
+            id: 'sample-sheet',
+            originalName: 'Dữ liệu bán hàng.xlsx',
+            displayName: 'Dữ liệu bán hàng.xlsx',
+            size: 1.8 * 1024 * 1024,
+            type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            uploadDate: new Date(now - 7 * 24 * 60 * 60 * 1000).toISOString(),
+            extension: '.xlsx'
+        }
     ];
-    
+
     createFileList(sampleFiles);
     if (window.toastSystem) {
         window.toastSystem.success('Đã tạo 4 tệp mẫu để bạn trải nghiệm!', {
@@ -201,61 +490,99 @@ window.createSampleFiles = function() {
 
 // Create file list display
 function createFileList(files) {
-    const filesContent = document.getElementById('files-content');
-    const emptyState = document.getElementById('empty-state');
-    
-    if (emptyState) emptyState.style.display = 'none';
-    if (filesContent) {
-        filesContent.classList.add('has-files');
-        filesContent.style.display = 'block';
-        filesContent.innerHTML = createFileListHTML(files);
-        
-        // Update file count
-        updateFileCount(files);
-        
-        // Add file interactions
-        addFileInteractions();
-    }
+    setAllFiles(Array.isArray(files) ? files : []);
 }
 
 // Generate HTML for file list
 function createFileListHTML(files) {
+    const listClassName = `file-list ${activeViewMode === 'grid' ? 'grid-view' : 'list-view'}`;
+
     return `
-        <div class="file-list list-view">
-            ${files.map(file => `
-                <div class="file-item" data-file-id="${file.id}" data-file-name="${file.originalName}">
-                    <div class="file-icon-wrapper ${file.isImage ? 'image-preview' : ''}" ${file.isImage ? `style="background-image: url('/api/preview/${file.id}'); background-size: cover; background-position: center;"` : ''}>
+        <div class="${listClassName}">
+            ${files.map(file => {
+                const shareState = getInitialShareState(file);
+                const displayNameRaw = file.displayName || file.originalName || file.name || 'Không có tên';
+                const originalNameRaw = file.originalName || displayNameRaw;
+                const fileIdRaw = file.id || file.internalName || originalNameRaw;
+                const mimeTypeRaw = file.type || '';
+                const typeLabelRaw = mimeTypeRaw || (file.extension ? file.extension.replace('.', '').toUpperCase() : 'Không xác định');
+                const sizeLabel = formatFileSize(file.size);
+                const dateValue = getDisplayDateValue(file);
+                const dateLabel = formatDate(dateValue);
+
+                const displayNameHtml = escapeHtml(displayNameRaw);
+                const fileIdAttr = escapeHtml(fileIdRaw);
+                const typeLabelHtml = escapeHtml(typeLabelRaw);
+                const sizeLabelHtml = escapeHtml(sizeLabel);
+                const dateLabelHtml = escapeHtml(dateLabel);
+
+                const fileIdJs = escapeForJsString(fileIdRaw);
+                const originalNameJs = escapeForJsString(originalNameRaw);
+                const mimeTypeJs = escapeForJsString(mimeTypeRaw);
+                const displayNameJs = escapeForJsString(displayNameRaw);
+
+                const previewBackground = file.isImage
+                    ? `style="background-image: url('/api/preview/${encodeURIComponent(fileIdRaw)}'); background-size: cover; background-position: center;"`
+                    : '';
+
+                return `
+                <div class="file-item" data-file-id="${fileIdAttr}" data-file-name="${displayNameHtml}" data-share-state="${shareState}">
+                    <div class="file-icon-wrapper ${file.isImage ? 'image-preview' : ''}" ${previewBackground}>
                         ${!file.isImage ? `<i class="fas ${getFileIconClass(file)}"></i>` : ''}
                     </div>
                     <div class="file-details">
-                        <div class="file-name" title="${file.originalName}">${file.originalName}</div>
+                        <div class="file-name" title="${displayNameHtml}">${displayNameHtml}</div>
                         <div class="file-meta">
-                            <span class="file-size">${formatFileSize(file.size)}</span>
-                            <span class="file-date">${formatDate(file.uploadDate)}</span>
-                            <span class="file-type">${file.type}</span>
+                            <span class="file-size">${sizeLabelHtml}</span>
+                            <span class="file-date">${dateLabelHtml}</span>
+                            <span class="file-type">${typeLabelHtml}</span>
                         </div>
                     </div>
                     <div class="file-actions">
-                        <button class="action-btn preview-btn" title="Xem trước" onclick="previewFile('${file.id}', '${file.originalName}', '${file.type}')">
+                        <button class="action-btn preview-btn" title="Xem trước" onclick="previewFile('${fileIdJs}', '${originalNameJs}', '${mimeTypeJs}')">
                             <i class="fas fa-eye"></i>
                         </button>
-                        <button class="action-btn details-btn" title="Xem chi tiết" onclick="viewFileDetails('${file.id}', '${file.originalName}')">
+                        <button class="action-btn details-btn" title="Xem chi tiết" onclick="viewFileDetails('${fileIdJs}', '${originalNameJs}')">
                             <i class="fas fa-info-circle"></i>
                         </button>
-                        <button class="action-btn download-btn" title="Tải xuống" onclick="downloadFile('${file.id}', '${file.originalName}')">
+                        <button class="action-btn download-btn" title="Tải xuống" onclick="downloadFile('${fileIdJs}', '${originalNameJs}')">
                             <i class="fas fa-download"></i>
                         </button>
-                        <button class="action-btn rename-btn" title="Đổi tên" onclick="renameFile('${file.id}', '${file.displayName || file.originalName}')">
+                        <button class="action-btn share-toggle-btn" title="${shareState === 'public' ? 'Đang công khai' : 'Đang riêng tư'}" data-share-state="${shareState}">
+                            <i class="fas ${shareState === 'public' ? 'fa-lock-open' : 'fa-lock'}"></i>
+                        </button>
+                        <button class="action-btn rename-btn" title="Đổi tên" onclick="renameFile('${fileIdJs}', '${displayNameJs}')">
                             <i class="fas fa-edit"></i>
                         </button>
-                        <button class="action-btn delete-btn" title="Xóa" onclick="deleteFile('${file.id}', '${file.displayName || file.originalName}')">
+                        <button class="action-btn delete-btn" title="Xóa" onclick="deleteFile('${fileIdJs}', '${displayNameJs}')">
                             <i class="fas fa-trash"></i>
                         </button>
                     </div>
                 </div>
-            `).join('')}
+            `}).join('')}
         </div>
     `;
+}
+
+function getInitialShareState(file) {
+    if (file && typeof file.isPublic === 'boolean') {
+        return file.isPublic ? 'public' : 'private';
+    }
+
+    if (!file || !file.metadata) {
+        return 'private';
+    }
+
+    const metadata = file.metadata;
+    if (metadata.shareStatus && ['public', 'private'].includes(metadata.shareStatus)) {
+        return metadata.shareStatus;
+    }
+
+    if (typeof metadata.isPublic === 'boolean') {
+        return metadata.isPublic ? 'public' : 'private';
+    }
+
+    return 'private';
 }
 
 // Get file icon class based on file object
@@ -278,18 +605,41 @@ function getFileIconClass(file) {
 
 // Format file size
 function formatFileSize(bytes) {
-    if (bytes === 0) return '0 Bytes';
+    const numericBytes = typeof bytes === 'number' ? bytes : Number(bytes);
+
+    if (!Number.isFinite(numericBytes) || numericBytes < 0) {
+        return 'Không xác định';
+    }
+
+    if (numericBytes === 0) {
+        return '0 Bytes';
+    }
+
     const k = 1024;
-    const sizes = ['Bytes', 'KB', 'MB', 'GB'];
-    const i = Math.floor(Math.log(bytes) / Math.log(k));
-    return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+    const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
+    const index = Math.min(Math.floor(Math.log(numericBytes) / Math.log(k)), sizes.length - 1);
+    const scaledValue = numericBytes / Math.pow(k, index);
+
+    return `${parseFloat(scaledValue.toFixed(2))} ${sizes[index]}`;
 }
 
 // Format date
 function formatDate(dateString) {
+    if (!dateString) {
+        return 'Không xác định';
+    }
+
     const date = new Date(dateString);
+    if (Number.isNaN(date.getTime())) {
+        return 'Không xác định';
+    }
+
     const now = new Date();
     const diffTime = now - date; // Remove Math.abs to get correct direction
+    if (!Number.isFinite(diffTime)) {
+        return 'Không xác định';
+    }
+
     const diffMinutes = Math.floor(diffTime / (1000 * 60));
     const diffHours = Math.floor(diffTime / (1000 * 60 * 60));
     const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24));
@@ -329,10 +679,19 @@ function formatDate(dateString) {
 }
 
 // Update file count display
-function updateFileCount(files) {
+function updateFileCount(files, totalFilesCount) {
     const fileCount = document.querySelector('.file-count');
-    if (fileCount) {
-        fileCount.textContent = `${files.length} tệp tin`;
+    if (!fileCount) {
+        return;
+    }
+
+    const currentCount = Array.isArray(files) ? files.length : Number(files) || 0;
+    const totalCount = typeof totalFilesCount === 'number' ? totalFilesCount : currentCount;
+
+    if (totalCount && totalCount !== currentCount) {
+        fileCount.textContent = `${currentCount}/${totalCount} tệp tin`;
+    } else {
+        fileCount.textContent = `${currentCount} tệp tin`;
     }
 }
 
@@ -340,7 +699,7 @@ function updateFileCount(files) {
 function addFileInteractions() {
     const fileItems = document.querySelectorAll('.file-item');
     const actionBtns = document.querySelectorAll('.action-btn');
-    
+
     fileItems.forEach(item => {
         item.addEventListener('click', function(e) {
             if (!e.target.closest('.action-btn')) {
@@ -355,11 +714,15 @@ function addFileInteractions() {
     });
     
     actionBtns.forEach(btn => {
+        if (btn.classList.contains('share-toggle-btn')) {
+            return;
+        }
+
         btn.addEventListener('click', function(e) {
             e.stopPropagation();
             const action = this.title;
             const fileName = this.closest('.file-item').getAttribute('data-file-name');
-            
+
             switch(action) {
                 case 'Tải xuống':
                     if (window.toastSystem) {
@@ -382,6 +745,53 @@ function addFileInteractions() {
             }
         });
     });
+
+    const shareToggleButtons = document.querySelectorAll('.share-toggle-btn');
+    shareToggleButtons.forEach(button => {
+        const state = button.getAttribute('data-share-state') || 'private';
+        updateShareToggleVisuals(button, state);
+
+        button.addEventListener('click', function(e) {
+            e.preventDefault();
+            e.stopPropagation();
+
+            const newState = toggleShareStatus(button);
+            const fileItem = button.closest('.file-item');
+            if (fileItem) {
+                fileItem.setAttribute('data-share-state', newState);
+
+                if (window.toastSystem) {
+                    const fileName = fileItem.getAttribute('data-file-name');
+                    const stateLabel = newState === 'public' ? 'công khai' : 'riêng tư';
+                    window.toastSystem.success(`Đã chuyển "${fileName}" sang chế độ ${stateLabel}`, {
+                        duration: 2500
+                    });
+                }
+            }
+        });
+    });
+}
+
+function toggleShareStatus(button) {
+    const currentState = button.getAttribute('data-share-state') === 'public' ? 'public' : 'private';
+    const newState = currentState === 'public' ? 'private' : 'public';
+    button.setAttribute('data-share-state', newState);
+    updateShareToggleVisuals(button, newState);
+    return newState;
+}
+
+function updateShareToggleVisuals(button, state) {
+    const icon = button.querySelector('i');
+    if (icon) {
+        icon.className = `fas ${state === 'public' ? 'fa-lock-open' : 'fa-lock'}`;
+    }
+
+    button.title = state === 'public' ? 'Đang công khai' : 'Đang riêng tư';
+    if (state === 'public') {
+        button.classList.add('is-public');
+    } else {
+        button.classList.remove('is-public');
+    }
 }
 
 // CRUD Operations

--- a/public/js/pages/sso/auth.js
+++ b/public/js/pages/sso/auth.js
@@ -1,0 +1,96 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const forms = document.querySelectorAll('.auth-form');
+    const passwordToggles = document.querySelectorAll('.password-toggle');
+
+    passwordToggles.forEach(button => {
+        button.addEventListener('click', () => togglePasswordVisibility(button));
+    });
+
+    forms.forEach(form => {
+        const alertBox = form.querySelector('.auth-alert');
+
+        form.addEventListener('input', () => {
+            hideAlert(alertBox);
+        });
+
+        form.addEventListener('submit', event => {
+            event.preventDefault();
+            handleSubmit(form, alertBox);
+        });
+    });
+});
+
+function handleSubmit(form, alertBox) {
+    if (!form.checkValidity()) {
+        form.reportValidity();
+        showAlert(alertBox, 'error', 'Vui lòng kiểm tra lại thông tin.');
+        return;
+    }
+
+    const formType = form.dataset.formType;
+
+    if (formType === 'register') {
+        const password = form.querySelector('#register-password').value.trim();
+        const confirm = form.querySelector('#register-confirm').value.trim();
+
+        if (password !== confirm) {
+            showAlert(alertBox, 'error', 'Mật khẩu xác nhận chưa trùng khớp.');
+            return;
+        }
+    }
+
+    showAlert(alertBox, 'success', getSuccessMessage(formType));
+    form.reset();
+    resetPasswordFields(form);
+}
+
+function getSuccessMessage(type) {
+    switch (type) {
+        case 'login':
+            return 'Đăng nhập thành công (mô phỏng).';
+        case 'register':
+            return 'Tạo tài khoản thành công (mô phỏng).';
+        case 'forgot':
+            return 'Đã gửi hướng dẫn đặt lại mật khẩu (mô phỏng).';
+        default:
+            return 'Thao tác hoàn tất.';
+    }
+}
+
+function togglePasswordVisibility(button) {
+    const field = button.previousElementSibling;
+
+    if (!field) return;
+
+    const showing = field.type === 'text';
+    field.type = showing ? 'password' : 'text';
+    button.textContent = showing ? 'Hiện' : 'Ẩn';
+}
+
+function resetPasswordFields(form) {
+    const passwordInputs = form.querySelectorAll('.password-field input');
+    const toggleButtons = form.querySelectorAll('.password-toggle');
+
+    passwordInputs.forEach(input => {
+        input.type = 'password';
+    });
+
+    toggleButtons.forEach(button => {
+        button.textContent = 'Hiện';
+    });
+}
+
+function showAlert(alertBox, status, message) {
+    if (!alertBox) return;
+
+    alertBox.textContent = message;
+    alertBox.classList.remove('is-error', 'is-success');
+    alertBox.classList.add(status === 'error' ? 'is-error' : 'is-success');
+}
+
+function hideAlert(alertBox) {
+    if (!alertBox) return;
+
+    alertBox.textContent = '';
+    alertBox.classList.remove('is-error', 'is-success');
+}


### PR DESCRIPTION
## Summary
- add stylesheet fallbacks on the login, register, and forgot-password forms so they automatically recover if the relative CSS paths fail to load
- dynamically load the shared SSO script with a fallback URL to keep validation and interactions working even when the primary bundle is unreachable

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68e3866fadf8832dab302ee28f7b5a92