### PR TITLE
Add recycle bin support

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,6 +93,10 @@
                     <i class="fas fa-folder"></i>
                     <span>My Files</span>
                 </a>
+                <a href="/recycle" class="nav-item" data-page="recycle-bin">
+                    <i class="fas fa-trash"></i>
+                    <span>Recycle Bin</span>
+                </a>
                 <a href="#" class="nav-item" data-page="subscription">
                     <i class="fas fa-credit-card"></i>
                     <span>Subscription</span>
@@ -124,6 +128,10 @@
         <a href="#" class="nav-item active" data-page="myfiles">
             <i class="fas fa-folder"></i>
             <span>My Files</span>
+        </a>
+        <a href="/recycle" class="nav-item" data-page="recycle-bin">
+            <i class="fas fa-trash"></i>
+            <span>Recycle Bin</span>
         </a>
         <a href="#" class="nav-item" data-page="subscription">
             <i class="fas fa-credit-card"></i>

--- a/public/js/pages/myfiles.js
+++ b/public/js/pages/myfiles.js
@@ -1848,9 +1848,9 @@ window.deleteFile = async function(fileId, fileName) {
     }
 
     const confirmed = await window.modalSystem.confirm({
-        title: 'Xác nhận xóa tệp',
-        message: `Bạn có chắc muốn xóa "${fileName}"? Hành động này không thể hoàn tác.`,
-        confirmText: 'Xóa',
+        title: 'Chuyển vào thùng rác',
+        message: `"${fileName}" sẽ được chuyển vào Thùng rác và lưu giữ trong 30 ngày trước khi xóa vĩnh viễn. Bạn có chắc chắn tiếp tục?`,
+        confirmText: 'Chuyển vào thùng rác',
         cancelText: 'Hủy',
         confirmClass: 'btn-danger'
     });
@@ -1874,7 +1874,7 @@ window.deleteFile = async function(fileId, fileName) {
         const result = await response.json();
 
         if (result.success) {
-            window.toastSystem.success(`Đã xóa ${fileName}`);
+            window.toastSystem.success(`Đã chuyển ${fileName} vào Thùng rác (giữ 30 ngày).`);
             // Reload file list
             loadFiles();
         } else {

--- a/public/pages/recycle_bin/index.html
+++ b/public/pages/recycle_bin/index.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>BeamShare - Thùng rác</title>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="/public/css/base.css">
+    <link rel="stylesheet" href="/public/css/modal-toast.css">
+    <link rel="stylesheet" href="/public/css/file-icons.css">
+    <link rel="stylesheet" href="/public/pages/recycle_bin/style.css">
+</head>
+<body>
+    <div class="recycle-app">
+        <header class="recycle-header">
+            <div class="recycle-header__left">
+                <a class="recycle-back" href="/">
+                    <i class="fas fa-arrow-left"></i>
+                    <span>Quay lại BeamShare Drive</span>
+                </a>
+            </div>
+            <div class="recycle-header__center">
+                <h1>Thùng rác</h1>
+                <p>Lưu trữ tạm thời các tệp đã xóa trong 30 ngày</p>
+            </div>
+            <div class="recycle-header__actions">
+                <button id="refresh-recycle" class="recycle-btn recycle-btn--ghost" type="button">
+                    <i class="fas fa-sync-alt"></i>
+                    <span>Làm mới</span>
+                </button>
+            </div>
+        </header>
+
+        <main class="recycle-main">
+            <section class="recycle-summary" aria-live="polite">
+                <div class="summary-item">
+                    <i class="fas fa-clock"></i>
+                    <div>
+                        <strong>Thời gian lưu</strong>
+                        <span>Tệp sẽ tự động xóa sau 30 ngày kể từ lúc chuyển vào thùng rác.</span>
+                    </div>
+                </div>
+                <div class="summary-item" id="summary-total">
+                    <i class="fas fa-file"></i>
+                    <div>
+                        <strong>Tổng tệp</strong>
+                        <span>Đang đếm...</span>
+                    </div>
+                </div>
+            </section>
+
+            <section class="recycle-table" aria-label="Danh sách tệp trong thùng rác">
+                <div id="recycle-loading" class="recycle-loading" role="status">
+                    <i class="fas fa-spinner fa-spin"></i>
+                    <span>Đang tải danh sách thùng rác...</span>
+                </div>
+                <div id="recycle-empty" class="recycle-empty" hidden>
+                    <i class="fas fa-check-circle"></i>
+                    <p>Thùng rác đang trống. Các tệp đã xóa sẽ xuất hiện tại đây.</p>
+                </div>
+                <div class="recycle-table__container" id="recycle-table-container" hidden>
+                    <table>
+                        <thead>
+                            <tr>
+                                <th scope="col">Tên tệp</th>
+                                <th scope="col">Kích thước</th>
+                                <th scope="col">Đã xóa lúc</th>
+                                <th scope="col">Thời gian còn lại</th>
+                                <th scope="col" class="actions">Thao tác</th>
+                            </tr>
+                        </thead>
+                        <tbody id="recycle-table-body"></tbody>
+                    </table>
+                </div>
+            </section>
+        </main>
+    </div>
+
+    <script src="/public/js/modal-system.js"></script>
+    <script src="/public/js/toast-system.js"></script>
+    <script src="/public/pages/recycle_bin/recycle-bin.js" type="module"></script>
+</body>
+</html>

--- a/public/pages/recycle_bin/recycle-bin.js
+++ b/public/pages/recycle_bin/recycle-bin.js
@@ -1,0 +1,246 @@
+const RETENTION_DAYS = 30;
+const tableBody = document.getElementById('recycle-table-body');
+const tableContainer = document.getElementById('recycle-table-container');
+const loadingState = document.getElementById('recycle-loading');
+const emptyState = document.getElementById('recycle-empty');
+const refreshButton = document.getElementById('refresh-recycle');
+const summaryTotal = document.querySelector('#summary-total span');
+
+function escapeHtml(value) {
+    if (value === null || value === undefined) {
+        return '';
+    }
+
+    return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+function formatFileSize(bytes) {
+    if (!Number.isFinite(bytes) || bytes <= 0) {
+        return '—';
+    }
+    const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+    const value = bytes / Math.pow(1024, exponent);
+    return `${value.toFixed(value >= 100 ? 0 : value >= 10 ? 1 : 2)} ${units[exponent]}`;
+}
+
+function formatDateTime(value) {
+    if (!value) {
+        return '—';
+    }
+
+    try {
+        const date = value instanceof Date ? value : new Date(value);
+        return new Intl.DateTimeFormat('vi-VN', {
+            year: 'numeric',
+            month: 'short',
+            day: '2-digit',
+            hour: '2-digit',
+            minute: '2-digit'
+        }).format(date);
+    } catch (_error) {
+        return '—';
+    }
+}
+
+function formatRemainingTime(expiresAt) {
+    if (!expiresAt) {
+        return '—';
+    }
+
+    const now = Date.now();
+    const expiry = expiresAt instanceof Date ? expiresAt.getTime() : new Date(expiresAt).getTime();
+    if (Number.isNaN(expiry)) {
+        return '—';
+    }
+
+    const diff = expiry - now;
+    if (diff <= 0) {
+        return '<span class="time-expired">Sắp xóa</span>';
+    }
+
+    const totalMinutes = Math.floor(diff / 60000);
+    const days = Math.floor(totalMinutes / (60 * 24));
+    const hours = Math.floor((totalMinutes % (60 * 24)) / 60);
+    const minutes = totalMinutes % 60;
+
+    if (days > 0) {
+        return `${days} ngày ${hours} giờ`;
+    }
+    if (hours > 0) {
+        return `${hours} giờ ${minutes} phút`;
+    }
+    return `${Math.max(minutes, 1)} phút`;
+}
+
+function renderRows(files = []) {
+    tableBody.innerHTML = '';
+
+    files.forEach((file) => {
+        const row = document.createElement('tr');
+        const displayName = escapeHtml(file.displayName || file.originalName);
+        const originalName = escapeHtml(file.originalName || '');
+        const remainingHtml = formatRemainingTime(file.recycleExpiresAt);
+        row.innerHTML = `
+            <td>
+                <div class="file-name">
+                    <strong>${displayName}</strong>
+                    ${file.displayName !== file.originalName && file.originalName ? `<div class="file-name__muted">${originalName}</div>` : ''}
+                </div>
+            </td>
+            <td>${formatFileSize(file.size)}</td>
+            <td>${formatDateTime(file.deletedAt)}</td>
+            <td>${remainingHtml}</td>
+            <td class="actions">
+                <div class="recycle-actions">
+                    <button class="recycle-action-btn restore" type="button">
+                        <i class="fas fa-undo"></i>
+                        Khôi phục
+                    </button>
+                    <button class="recycle-action-btn delete" type="button">
+                        <i class="fas fa-trash-alt"></i>
+                        Xóa vĩnh viễn
+                    </button>
+                </div>
+            </td>
+        `;
+
+        const [restoreBtn, deleteBtn] = row.querySelectorAll('button');
+        restoreBtn.dataset.file = file.internalName;
+        deleteBtn.dataset.file = file.internalName;
+        restoreBtn.addEventListener('click', () => handleRestore(file));
+        deleteBtn.addEventListener('click', () => handlePermanentDelete(file));
+        tableBody.appendChild(row);
+    });
+}
+
+function setViewState({ isLoading, hasData }) {
+    if (isLoading) {
+        loadingState?.removeAttribute('hidden');
+    } else {
+        loadingState?.setAttribute('hidden', '');
+    }
+
+    if (!hasData && !isLoading) {
+        emptyState?.removeAttribute('hidden');
+        tableContainer?.setAttribute('hidden', '');
+    } else if (hasData) {
+        emptyState?.setAttribute('hidden', '');
+        tableContainer?.removeAttribute('hidden');
+    }
+}
+
+async function fetchRecycleBin() {
+    setViewState({ isLoading: true, hasData: false });
+    try {
+        const response = await fetch('/api/recycle-bin');
+        if (!response.ok) {
+            throw new Error(await response.text() || 'Không thể tải thùng rác');
+        }
+
+        const payload = await response.json();
+        const files = Array.isArray(payload?.files) ? payload.files : [];
+
+        summaryTotal.textContent = `${files.length} tệp`;
+        renderRows(files);
+        setViewState({ isLoading: false, hasData: files.length > 0 });
+    } catch (error) {
+        console.error('Recycle bin load failed:', error);
+        summaryTotal.textContent = 'Không thể tải';
+        setViewState({ isLoading: false, hasData: false });
+        window.toastSystem?.error('Không thể tải danh sách thùng rác. Vui lòng thử lại.');
+    }
+}
+
+async function handleRestore(file) {
+    const displayName = file.displayName || file.originalName;
+    const confirmMessage = `Khôi phục "${displayName}" về thư mục My Files?`;
+    const confirmed = await askForConfirmation({
+        title: 'Khôi phục tệp',
+        message: confirmMessage,
+        confirmText: 'Khôi phục'
+    });
+
+    if (!confirmed) {
+        return;
+    }
+
+    try {
+        const response = await fetch(`/api/recycle-bin/${encodeURIComponent(file.internalName)}/restore`, {
+            method: 'POST'
+        });
+
+        if (!response.ok) {
+            const payload = await response.json().catch(() => ({}));
+            throw new Error(payload.error || 'Không thể khôi phục tệp');
+        }
+
+        window.toastSystem?.success(`Đã khôi phục "${displayName}".`);
+        await fetchRecycleBin();
+    } catch (error) {
+        console.error('Restore failed:', error);
+        window.toastSystem?.error(error.message || 'Không thể khôi phục tệp.');
+    }
+}
+
+async function handlePermanentDelete(file) {
+    const displayName = file.displayName || file.originalName;
+    const confirmMessage = `Xóa vĩnh viễn "${displayName}"? Hành động này không thể hoàn tác.`;
+    const confirmed = await askForConfirmation({
+        title: 'Xóa vĩnh viễn',
+        message: confirmMessage,
+        confirmText: 'Xóa vĩnh viễn',
+        confirmClass: 'btn-danger'
+    });
+
+    if (!confirmed) {
+        return;
+    }
+
+    try {
+        const response = await fetch(`/api/recycle-bin/${encodeURIComponent(file.internalName)}`, {
+            method: 'DELETE'
+        });
+
+        if (!response.ok) {
+            const payload = await response.json().catch(() => ({}));
+            throw new Error(payload.error || 'Không thể xóa vĩnh viễn tệp');
+        }
+
+        window.toastSystem?.success(`Đã xóa vĩnh viễn "${displayName}".`);
+        await fetchRecycleBin();
+    } catch (error) {
+        console.error('Permanent delete failed:', error);
+        window.toastSystem?.error(error.message || 'Không thể xóa vĩnh viễn tệp.');
+    }
+}
+
+async function askForConfirmation(options) {
+    if (window.modalSystem && typeof window.modalSystem.confirm === 'function') {
+        return window.modalSystem.confirm({
+            cancelText: 'Hủy',
+            ...options
+        });
+    }
+
+    return window.confirm(options?.message || 'Bạn có chắc chắn?');
+}
+
+refreshButton?.addEventListener('click', () => {
+    fetchRecycleBin();
+});
+
+document.addEventListener('DOMContentLoaded', () => {
+    summaryTotal.textContent = 'Đang tải...';
+    fetchRecycleBin();
+});
+
+window.recycleBin = {
+    refresh: fetchRecycleBin,
+    retentionDays: RETENTION_DAYS
+};

--- a/public/pages/recycle_bin/style.css
+++ b/public/pages/recycle_bin/style.css
@@ -1,0 +1,280 @@
+:root {
+    --recycle-bg: #f4f6fb;
+    --recycle-panel: #ffffff;
+    --recycle-border: #e2e8f0;
+    --recycle-text: #1f2937;
+    --recycle-muted: #6b7280;
+    --recycle-accent: #2563eb;
+    --recycle-danger: #ef4444;
+    --recycle-success: #059669;
+}
+
+body {
+    font-family: 'Inter', 'Segoe UI', Tahoma, sans-serif;
+    background: var(--recycle-bg);
+    color: var(--recycle-text);
+    margin: 0;
+    min-height: 100vh;
+}
+
+.recycle-app {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+}
+
+.recycle-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 24px clamp(16px, 4vw, 48px);
+    background: linear-gradient(135deg, #1f2937 0%, #111827 100%);
+    color: #fff;
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.3);
+}
+
+.recycle-header__left,
+.recycle-header__actions {
+    flex: 1;
+    display: flex;
+    align-items: center;
+}
+
+.recycle-header__center {
+    flex: 2;
+    text-align: center;
+}
+
+.recycle-header__center h1 {
+    margin: 0 0 6px;
+    font-size: clamp(24px, 3vw, 36px);
+    font-weight: 700;
+}
+
+.recycle-header__center p {
+    margin: 0;
+    font-size: 15px;
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.recycle-back {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 16px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.12);
+    color: #fff;
+    text-decoration: none;
+    transition: background 0.2s ease;
+    font-weight: 500;
+}
+
+.recycle-back:hover {
+    background: rgba(255, 255, 255, 0.2);
+}
+
+.recycle-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 18px;
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    background: transparent;
+    border-radius: 999px;
+    color: #fff;
+    cursor: pointer;
+    font-weight: 600;
+    transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.recycle-btn i {
+    font-size: 14px;
+}
+
+.recycle-btn:hover {
+    transform: translateY(-1px);
+    background: rgba(255, 255, 255, 0.15);
+}
+
+.recycle-main {
+    flex: 1;
+    padding: clamp(24px, 4vw, 48px);
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.recycle-summary {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 16px;
+}
+
+.summary-item {
+    display: flex;
+    gap: 14px;
+    padding: 18px 20px;
+    border-radius: 16px;
+    background: var(--recycle-panel);
+    border: 1px solid var(--recycle-border);
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.05);
+}
+
+.summary-item i {
+    font-size: 28px;
+    color: var(--recycle-accent);
+}
+
+.summary-item strong {
+    display: block;
+    font-size: 16px;
+    margin-bottom: 4px;
+}
+
+.summary-item span {
+    color: var(--recycle-muted);
+    font-size: 14px;
+}
+
+.recycle-table {
+    flex: 1;
+    background: var(--recycle-panel);
+    border-radius: 20px;
+    border: 1px solid var(--recycle-border);
+    box-shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
+    overflow: hidden;
+}
+
+.recycle-loading,
+.recycle-empty {
+    text-align: center;
+    padding: 48px 24px;
+    color: var(--recycle-muted);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
+}
+
+.recycle-empty i {
+    font-size: 40px;
+    color: var(--recycle-success);
+}
+
+.recycle-table__container {
+    overflow-x: auto;
+}
+
+.recycle-table table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.recycle-table thead {
+    background: #f8fafc;
+}
+
+.recycle-table th,
+.recycle-table td {
+    padding: 16px 20px;
+    border-bottom: 1px solid var(--recycle-border);
+    text-align: left;
+    font-size: 14px;
+}
+
+.recycle-table tbody tr:hover {
+    background: #f1f5f9;
+}
+
+.recycle-table td.actions {
+    text-align: right;
+}
+
+.file-name {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.file-name__muted {
+    color: var(--recycle-muted);
+    font-size: 12px;
+}
+
+.recycle-actions {
+    display: inline-flex;
+    gap: 8px;
+}
+
+.recycle-action-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 14px;
+    border-radius: 999px;
+    border: 1px solid transparent;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.recycle-action-btn i {
+    font-size: 13px;
+}
+
+.recycle-action-btn.restore {
+    background: rgba(37, 99, 235, 0.1);
+    color: var(--recycle-accent);
+    border-color: rgba(37, 99, 235, 0.2);
+}
+
+.recycle-action-btn.restore:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 16px rgba(37, 99, 235, 0.2);
+}
+
+.recycle-action-btn.delete {
+    background: rgba(239, 68, 68, 0.08);
+    color: var(--recycle-danger);
+    border-color: rgba(239, 68, 68, 0.2);
+}
+
+.recycle-action-btn.delete:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 16px rgba(239, 68, 68, 0.25);
+}
+
+.time-expired {
+    color: var(--recycle-danger);
+    font-weight: 600;
+}
+
+@media (max-width: 768px) {
+    .recycle-header {
+        flex-direction: column;
+        gap: 16px;
+        text-align: center;
+    }
+
+    .recycle-header__left,
+    .recycle-header__actions {
+        justify-content: center;
+    }
+
+    .recycle-table th,
+    .recycle-table td {
+        padding: 12px 14px;
+    }
+
+    .recycle-actions {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .recycle-action-btn {
+        justify-content: center;
+        width: 100%;
+    }
+}


### PR DESCRIPTION
## Summary
- add soft delete state to file metadata and helper queries to support a recycle bin with automatic expiry
- expose recycle bin APIs for listing, restore, permanent delete, and guard file actions when items are trashed
- provide a dedicated recycle bin page, navigation entry, and server routing with scheduled cleanup

## Testing
- npm run start *(fails: requires uuid/dist/native.js in current node_modules tree)*

------
https://chatgpt.com/codex/tasks/task_e_6901e994e8d0832d957bdea1985d7eb0